### PR TITLE
Regularized Cost Function

### DIFF
--- a/hypothesis.m
+++ b/hypothesis.m
@@ -4,5 +4,5 @@
 % m - number of records, n - number of features
 % Returns predictions.
 function [predictions] = hypothesis(X, theta)
-  predictions = sigmoid(X * theta);
- end
+  predictions = sigmoid(X .* theta);
+end

--- a/logreg_cost.m
+++ b/logreg_cost.m
@@ -1,0 +1,22 @@
+% Cost function - Regularized cost for Logistic Regression Classification
+% Takes in:
+% X - training set (m x n Matrix)
+% y - training output values
+% theta - model parameters
+% lambda - regularization parameter
+% Returns Cost.
+function [cost] = logreg_cost(X, y, theta, lambda);
+  % Number of training records
+  m = size(y, 1);
+  
+  % Calculating Hypothesis using hypothesis.m
+  preds = hypothesis(X, theta);
+  
+  % Regularization Parameters
+  % First line of thetas, theta0, doesn't get regularized. Filtering them out to calculate regularization parameters.
+  reg_thetas = theta(2:end, 1);
+  reg_param = lambda / (2 * m) * (reg_thetas' .* reg_thetas);
+  
+  % Calculate Regularized Cost function
+  cost = (-1 / m) * (y' .* log(preds) + (1 - y)' .* log(1 - preds)) + reg_param;
+end

--- a/sigmoid.m
+++ b/sigmoid.m
@@ -2,4 +2,4 @@
 % Takes z (which is equivalent to: theta' * X) as the argument and returns the g(used in hypothesis) value. 
 function g = sigmoid(z)
   g = 1 ./ (1 + exp(-z));
- end
+end


### PR DESCRIPTION
Added cost function for Logistic Regression with regularization, since logistic regression is prone to overfitting. Regularization will penalize overfitted predictions.
Added file:
 - logreg_cost.m